### PR TITLE
use virtualenv to install fanficfare

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM golang:alpine
 
-WORKDIR /fanficfare
-
 RUN apk add --update py-pip git
 
+ENV PYTHONUNBUFFERED 1
+RUN python3 -m venv /opt/venv
+# Enable venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 RUN pip3 install FanFicFare --upgrade
+
+WORKDIR /fanficfare
 
 RUN go mod init fanficfare
 RUN go get -d -v github.com/labstack/echo/v4 github.com/labstack/echo/v4/middleware github.com/microcosm-cc/bluemonday


### PR DESCRIPTION
github actions does not seem to allow installation of pip packages outside of a virtual environment anymore. 